### PR TITLE
Add CondaRepo config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,11 @@ year={2019},
 
 Copyright 2015 Hatef Monajemi (monajemi@stanford.edu)
 
+## Cluster configuration
+
+Each cluster is described in the `ssh_config` file.  In addition to the existing
+`Repo` entry that controls where run data is stored, you can optionally specify
+`CondaRepo` to choose the directory where CJ installs Miniconda on that machine.
+If omitted, `CondaRepo` defaults to the same path as `Repo`.
+
 

--- a/src/CJ.pm
+++ b/src/CJ.pm
@@ -1696,13 +1696,14 @@ sub show_cluster_config{
 
 sub cluster_config_template{
     # for sorting purposes
-    my @config_keys=('Host','User','Bqs','Alloc','Repo','MAT','MATlib','Python','Pythonlib','R','Rlib');
+    my @config_keys=('Host','User','Bqs','Alloc','Repo','CondaRepo','MAT','MATlib','Python','Pythonlib','R','Rlib');
     my $cluster_config = {
         'Host' => {example=>'35.185.238.124', default=>undef},
         'User' => {example=>$CJID, default=>undef},
         'Bqs'  => {example=>undef, default=>'SLURM'},
         'Alloc'  => {example=>'-n 1 -N 1 -p gpu', default=>undef},
         'Repo' => {example=>'/home/ubuntu/CJRepo_Remote',default=>undef},
+        'CondaRepo' => {example=>'/home/ubuntu/CJConda', default=>undef},
         'MAT'  => {example=>undef,default=>'matlab/r2016b'},
         'MATlib' => {example=>undef,default=>'$app_install_dir/cvx:$app_install_dir/mosek/7/toolbox/r2013a'},
         'Python' => {example=>undef,default=>'python3.4'},
@@ -1962,6 +1963,10 @@ sub parse_ssh_config{
     
     my ($remote_repo)  = $this_machine_string =~ /Repo[\t\s]+?(.*)/i ;
     $remote_repo   = remove_white_space($remote_repo);
+
+    my ($conda_repo)  = $this_machine_string =~ /CondaRepo[\t\s]+?(.*)/i ;
+    $conda_repo   = remove_white_space($conda_repo);
+    $conda_repo   = $remote_repo if (!defined $conda_repo || $conda_repo eq '');
     
     my ($remote_matlab_lib)  =$this_machine_string =~ /MATlib[\t\s]+?(.*)/i;
     $remote_matlab_lib =remove_white_space($remote_matlab_lib);
@@ -1992,6 +1997,7 @@ sub parse_ssh_config{
     $ssh_config->{'bqs'}             = $bqs;
     $ssh_config->{'alloc'}           = $alloc;
     $ssh_config->{'remote_repo'}     = $remote_repo;
+    $ssh_config->{'conda_repo'}      = $conda_repo;
     $ssh_config->{'matlib'}          = $remote_matlab_lib;
     $ssh_config->{'mat'}             = $remote_matlab_module;
     $ssh_config->{'user'}            = $user;

--- a/src/CJ/Install.pm
+++ b/src/CJ/Install.pm
@@ -61,7 +61,9 @@ sub __apply_install{
     $cmd = "ssh $ssh->{account} 'cd \$HOME && bash -l $filename' ";
     system($cmd);
     
-    $cmd = "ssh $ssh->{account} 'if [ -d \$HOME/$self->{path} ] ; then mv \$HOME/$filename \$HOME/$self->{path}/; fi' ";
+    my $basepath = $installpath;
+    $basepath =~ s#/[^/]+$##;
+    $cmd = "ssh $ssh->{account} 'if [ -d $basepath ] ; then mv \$HOME/$filename $basepath/; fi' ";
     system($cmd);
     
     &CJ::message("----- END BASH ON $self->{'machine'}-----",1);
@@ -554,7 +556,9 @@ my ($force_tag) = @_;
     
 my $miniconda = "Miniconda3-latest-Linux-x86_64";
 my $distro  = "https://repo.continuum.io/miniconda/${miniconda}.sh";
-my $installpath = "\$HOME/$self->{path}/miniconda";
+my $ssh = CJ::host($self->{'machine'});
+my $conda_base  = defined $ssh->{conda_repo} ? $ssh->{conda_repo} : $ssh->{remote_repo};
+my $installpath = "$conda_base/$self->{path}/miniconda";
     
 
 # -------------------

--- a/ssh_config
+++ b/ssh_config
@@ -3,6 +3,7 @@ Host		login.sherlock.stanford.edu
 User		monajemi
 Bqs		SLURM
 Repo		/scratch/users/monajemi/CJRepo_Remote
+CondaRepo       /scratch/users/monajemi/CJConda
 MAT     	matlab/R2017a
 MATlib		~/BPDN/CVX/cvx:~/mosek/7/toolbox/r2013a
 Python		python/3.6


### PR DESCRIPTION
## Summary
- support `CondaRepo` field in `ssh_config`
- install Miniconda under `CondaRepo`
- document the new option in README
- update sample `ssh_config`

## Testing
- `perl -I src -c src/CJ/Install.pm` *(fails: can't locate Firebase.pm)*
- `perl -I src -c src/CJ.pm` *(fails: can't locate Data::UUID.pm)*