### PR TITLE
Disable automatic Firebase updates

### DIFF
--- a/src/CJ.pl
+++ b/src/CJ.pl
@@ -9,7 +9,6 @@ use lib "$Bin";  #for testing
 use lib "$Bin/external/firebase/lib";  
 use lib "$Bin/external/ouch/lib";
 
-use Firebase; 
 use Ouch;
 use File::chdir;
 use CJ;          # contains essential functions
@@ -89,14 +88,7 @@ if( -d "$info_dir" ){
 my @nosync_cmds = qw ( init who help -help -h -Help -HELP prompt version -v install-update sanity);
 my %nosync = map { $_ => 1 } @nosync_cmds;
 
-if($CJKEY && (!exists($nosync{$cjcmd0})) ){
-    #CJ::err("This action needs internet connection!") if (not defined $localIP);
-    eval {
-        &CJ::add_agent_to_remote();  # if there is no agent, add it.
-        $sync_status = &CJ::AutoSync();
-    };
-    
-}
+# Automatic Firebase sync disabled
 
 }
 

--- a/src/CJ.pm
+++ b/src/CJ.pm
@@ -69,20 +69,7 @@ sub init{
     &CJ::create_ssh_config_md5();
     
     
-	if(defined($CJKEY)){
-		# Add this agent to the the list of agents
-		eval{
-			CJ::add_agent_to_remote();
-			};
-		if( $@ ){
-			if($@->message eq '401 Unauthorized'){
-			CJ::warning("Your CJKEY is invalid. Please provide a valid one and then issue 'cj sync' ");
-			}else{
-			CJ::warning("Unable to connect to CJ database $@");	
-			}
-		}
-		&CJ::AutoSync() unless ($@);
-	}
+        # Skip automatic Firebase updates during initialization
 
 
 }
@@ -539,10 +526,7 @@ my $newinfo = &CJ::add_change_to_run_history($info->{'pid'}, $change, $type);
 
 &CJ::add_to_history($newinfo,$date,$type);
 
-# write runinfo to FB as well
-my $timestamp  = $date->{epoch};    
-my $inform = 1;
-&CJ::write2firebase($info->{'pid'},$newinfo, $timestamp, $inform);
+
 
 exit 0;
 }
@@ -958,10 +942,7 @@ sub clean
 my $change={date => $date, agent=>$AgentID};
 my $newinfo = &CJ::add_change_to_run_history($pid, $change, "clean");
 
-my $timestamp = $date->{epoch};
-# Write runinfo to FB as well
-my $inform = 1;
-&CJ::write2firebase($info->{'pid'},$newinfo, $timestamp, $inform);
+
 	    
     
 exit 0;

--- a/src/CJ/Run.pm
+++ b/src/CJ/Run.pm
@@ -352,8 +352,6 @@ my $runinfo={
 
 # add_record locally
 &CJ::add_record($runinfo);
-# write runinfo to FireBaee as well
-&CJ::write2firebase($pid,$runinfo,$date->{epoch},0);
 }
 
 
@@ -538,7 +536,6 @@ my $runinfo={
 
 
 &CJ::add_record($runinfo);
-&CJ::write2firebase($pid,$runinfo, $date->{epoch},0);  # send to CJ server
 }
 
 
@@ -782,7 +779,6 @@ pkgsize       => $pkgsize,
 
 
 &CJ::add_record($runinfo);
-&CJ::write2firebase($pid,$runinfo, $date->{epoch},0);  # send to CJ server
 }
 
 


### PR DESCRIPTION
## Summary
- stop calling `AutoSync` during initialization
- disable automatic sync at startup and remove Firebase import
- remove `write2firebase` calls from run routines

## Testing
- `perl -c src/CJ.pm` *(fails: Can't locate Data/UUID.pm)*
- `perl -c src/CJ.pl` *(fails: Can't locate File/chdir.pm)*